### PR TITLE
config_types: Add weight validation

### DIFF
--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -88,7 +88,10 @@ func (t *TargetGroupTuple) validate() error {
 	if t.ServiceName != nil && t.ServicePort == nil {
 		return errors.New("missing servicePort")
 	}
-	return nil
+	if t.Weight < 0 || t.Weight > 999 {
+		return errors.New("The weight for each target group must be between 0 and 999, inclusive")
+	}
+ 	return nil
 }
 
 // Information about the target group stickiness for a rule.

--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -88,10 +88,11 @@ func (t *TargetGroupTuple) validate() error {
 	if t.ServiceName != nil && t.ServicePort == nil {
 		return errors.New("missing servicePort")
 	}
-	if t.Weight < 0 || t.Weight > 999 {
+
+	if (t.Weight != nil) && (*(t.Weight) < 0 || *(t.Weight) > 999) {
 		return errors.New("The weight for each target group must be between 0 and 999, inclusive")
 	}
- 	return nil
+	return nil
 }
 
 // Information about the target group stickiness for a rule.

--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -1,7 +1,7 @@
 package ingress
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -89,8 +90,8 @@ func (t *TargetGroupTuple) validate() error {
 		return errors.New("missing servicePort")
 	}
 
-	if (t.Weight != nil) && (*(t.Weight) < 0 || *(t.Weight) > 999) {
-		return errors.New("The weight for each target group must be between 0 and 999, inclusive")
+	if aws.Int64Value(t.Weight) < 0 || aws.Int64Value(t.Weight) > 999 {
+		return errors.New("weight value not between 0 and 999, inclusive")
 	}
 	return nil
 }


### PR DESCRIPTION
Adding a model validation for weights as described in the AWS LB Documentation - 

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#:~:text=You%20can%20use%20forward%20actions%20to%20route%20requests%20to%20one%20or%20more%20target%20groups.%20If%20you%20specify%20multiple%20target%20groups%20for%20a%20forward%20action%2C%20you%20must%20specify%20a%20weight%20for%20each%20target%20group.%20Each%20target%20group%20weight%20is%20a%20value%20from%200%20to%20999.

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
